### PR TITLE
Improve `import_source()` function

### DIFF
--- a/tinker/main.py
+++ b/tinker/main.py
@@ -49,6 +49,9 @@ def import_source(path: str) -> None:
     """
     Import a module, identified by its path on disk.
 
+    This function was adapted from the Python 3 recipe for recreating the Python
+    2 `import_source()` function, adapted to fit the immediate needs.
+
     Arguments:
         path: Absolute or relative path to the file of the Python module to import.
     """
@@ -70,6 +73,7 @@ def import_source(path: str) -> None:
 
     assert isinstance(spec.loader, importlib.abc.Loader)
 
+    # Perform the actual import.
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     spec.loader.exec_module(module)

--- a/tinker/main.py
+++ b/tinker/main.py
@@ -58,7 +58,7 @@ def import_source(path: str) -> None:
 
     # Extract the name portion of the path.
     basename = os.path.basename(path)
-    module_name = os.path.splitext(basename)[0]
+    module_name = f"tinker.{os.path.splitext(basename)[0]}"
 
     # Get an import spec from the runtime.
     spec = importlib.util.spec_from_file_location(module_name, path)


### PR DESCRIPTION
This PR provides some small improvements to the `import_source()` function:
- minor improvements: rewrote comments and docstring
- wrote in logic to catch `None` values from the loader infrastructure; this happens when the path does not refer to a valid Python source
- upon @manthey's advice, attempt to disambiguate the created module names from ones that may exist in the system. The solution I chose is not entirely robust, but should be good enough for now and perhaps all intended use cases: we now simply prepend `tinker.` to the detected module name to avoid situations like a local file being named `os.py`, etc.

This PR closes #106, though not by doing what that issue requests, but rather by mooting that issue--it turns out we do want the modules in `sys.modules`, otherwise SMQTK can't pick up symbols defined therein. This may be a SMQTK issue, but perhaps not (calling @Purg to weigh in).