### PR TITLE
Add dependencies from pipfile to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+click>=7.1
+smqtk-core==0.15.0


### PR DESCRIPTION
This PR adds the package dependencies specified in Pipfile to requirements.txt. Since Pipfile is not used by the downstream package in the installation, this ensures that a package specifying tinker-engine as dependency does not have to take into account tinker-engine's dependencies. 